### PR TITLE
Only estimate noise when no threshold is specified

### DIFF
--- a/+hsst/+extractorMethod/@thresholding/getSnippets.m
+++ b/+hsst/+extractorMethod/@thresholding/getSnippets.m
@@ -6,10 +6,11 @@ function [ snips, time_stamps, property ] = getSnippets( rawWaveform, sample_fre
     window_align = round(window_size/3);
     
     % Estimate Threshold from raw waveform if none is set
-    noise_estimate = hsst.extractorMethod.thresholding.getNoiseEstimate( rawWaveform, sample_freq );
-    if nargin < 3 | isempty(threshold),
+    noise_estimate = [];
+    if nargin < 3 || isempty(threshold),
+        noise_estimate = hsst.extractorMethod.thresholding.getNoiseEstimate( rawWaveform, sample_freq );
         threshold = noise_estimate;
-    end    
+    end
     
     %% Code
     


### PR DESCRIPTION
Noise estimation can take a long time, and if the user passes it in, don't redo their work! Of course, the returned property.noise_estimate is then empty and so the user will need to provide their own noise estimate in the subsequent sorting and scoring methods.
