### PR TITLE
Replace deprecated `princomp` with `pca`

### DIFF
--- a/+hsst/+sortMethod/@KMeans/KMeans.m
+++ b/+hsst/+sortMethod/@KMeans/KMeans.m
@@ -58,7 +58,7 @@ classdef KMeans < hsst.sorter
                 chosen_indices(next_index) = 1;
             end
 
-            [COEFF, score] = princomp(wf);
+            [COEFF, score] = pca(wf);
             mean_waveform = mean(wf);
     
             low_d = score(chosen_indices, :);

--- a/+hsst/+sortMethod/@MATLAB_GMM_PCA/MATLAB_GMM_PCA.m
+++ b/+hsst/+sortMethod/@MATLAB_GMM_PCA/MATLAB_GMM_PCA.m
@@ -27,7 +27,7 @@ classdef MATLAB_GMM_PCA < hsst.sorter
             
             %% PCA Decomp
             
-            [coeff{1}, score{1}] = princomp(wf);
+            [coeff{1}, score{1}] = pca(wf);
             PCA_2D_point = score{1}(:,1:2);
             PCA_3D_point = score{1}(:,1:3);
             PCA_10D_point = score{1}(:,1:10);

--- a/+hsst/+sortMethod/@MATLAB_KMeans/MATLAB_KMeans.m
+++ b/+hsst/+sortMethod/@MATLAB_KMeans/MATLAB_KMeans.m
@@ -48,7 +48,7 @@ classdef MATLAB_KMeans < hsst.sorter
 %                 chosen_indices(next_index) = 1;
 %             end
 % 
-%             [COEFF, score] = princomp(est_mu_wf);
+%             [COEFF, score] = pca(est_mu_wf);
 %             mean_waveform = mean(est_mu_wf);
 %     
 %             low_d = score(chosen_indices, :);

--- a/+hsst/+sortMethod/@MATLAB_KMeans_PCA/MATLAB_KMeans_PCA.m
+++ b/+hsst/+sortMethod/@MATLAB_KMeans_PCA/MATLAB_KMeans_PCA.m
@@ -31,7 +31,7 @@ classdef MATLAB_KMeans_PCA < hsst.sorter
                        
             %% PCA Decomp
             
-            [coeff{1}, score{1}] = princomp(wf);
+            [coeff{1}, score{1}] = pca(wf);
             PCA_2D_point = score{1}(:,1:2);
             PCA_3D_point = score{1}(:,1:3);
             PCA_10D_point = score{1}(:,1:10);
@@ -58,7 +58,7 @@ classdef MATLAB_KMeans_PCA < hsst.sorter
 %                 chosen_indices(next_index) = 1;
 %             end
 % 
-%             [COEFF, score] = princomp(est_mu_wf);
+%             [COEFF, score] = pca(est_mu_wf);
 %             mean_waveform = mean(est_mu_wf);
 %     
 %             low_d = score(chosen_indices, :);

--- a/+hsst/@dataObject/dataObject.m
+++ b/+hsst/@dataObject/dataObject.m
@@ -285,7 +285,7 @@ classdef dataObject < handle
                 ylabel('PC 2');
                 title(PCA_Title);
             
-            [coeff{1}, score{1}] = princomp(wf);
+            [coeff{1}, score{1}] = pca(wf);
             PCA_2D_point_1 = score{1}(:,1);
             PCA_2D_point_2 = score{1}(:,2);
 

--- a/+hsst/sortSnips.m
+++ b/+hsst/sortSnips.m
@@ -8,7 +8,7 @@ function [ sort_IDs, parameter, property ] = sortSnips( snippets, time_stamps, s
 %   2 : Uses HSST to determing optimal parameter setting and returns output
 %
 % INPUTS
-%   snippets        (NxD) : waveform snippets
+%   snippets        (DxN) : waveform snippets
 %   time_stamps     (1xN) : vector of time stamps 
 %   sample_freq     (1x1) : sampling frequency (Hz)
 %   noise_estimate  (1x1) : estimate of noise floor (same units as snippets)

--- a/HSST Sorting Method Helper Files/DukeSortFiles/DukeSort-OldVersion/main_spike_sorting_v3.m
+++ b/HSST Sorting Method Helper Files/DukeSortFiles/DukeSort-OldVersion/main_spike_sorting_v3.m
@@ -76,7 +76,7 @@ numgroup=1;
 for mm=1:1
         dataXX=datass_test{mm};
         dataXX=XX;
-        [coeff{mm},score{mm}]=princomp(dataXX.');
+        [coeff{mm},score{mm}]=pca(dataXX.');
         point=[score{mm}(:,1),score{mm}(:,2),score{mm}(:,3)];
         z=datacc{mm};
         Point=[score{mm}(:,1),score{mm}(:,2)];
@@ -128,7 +128,7 @@ clear dataxx coeff score
      for mm=1:numgroup
         dataxx(:,:,mm)=ec_spikes(mm,:,:);
         dataXX=reshape(dataxx(:,:,mm),size(dataxx,1),size(dataxx,2));
-        [coeff{mm},score{mm}]=princomp(dataXX.');
+        [coeff{mm},score{mm}]=pca(dataXX.');
         point=[score{mm}(:,1),score{mm}(:,2)];
         figure;plot(score{mm}(:,1),score{mm}(:,2),'o');
 %         z=label+4;

--- a/HSST Sorting Method Helper Files/WaveClusFiles/Batch_files/wave_features.m
+++ b/HSST Sorting Method Helper Files/WaveClusFiles/Batch_files/wave_features.m
@@ -38,7 +38,7 @@ switch feature
         [max ind]=sort(sd);
         coeff(1:inputs)=ind(ls:-1:ls-inputs+1);
     case 'pca'
-        [C,S,L] = princomp(spikes);
+        [C,S,L] = pca(spikes);
         cc = S;
         inputs = 3; 
         coeff(1:3)=[1 2 3];

--- a/HSST Sorting Method Helper Files/WaveClusFiles/wave_features_wc.m
+++ b/HSST Sorting Method Helper Files/WaveClusFiles/wave_features_wc.m
@@ -41,7 +41,7 @@ switch feature
         [max ind]=sort(sd);
         coeff(1:inputs)=ind(ls:-1:ls-inputs+1);
     case 'pca'
-        [C,S,L] = princomp(spikes);
+        [C,S,L] = pca(spikes);
         cc = S;
         inputs = 3; 
         coeff(1:3)=[1 2 3];


### PR DESCRIPTION
`princomp` was deprecated by MATLAB a few years ago and its functionality was fully absorbed by `pca`. Replacing all references to `princomp` with `pca` to help any future users.